### PR TITLE
Unimportant // Renamed a test case

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -88,7 +88,7 @@ class TestAmazonApi(TestCase):
             AMAZON_ASSOC_TAG)
         assert_equals(amazon.api.Region, "US")
 
-    def test_search_amazon_germany(self):
+    def test_search_amazon_uk(self):
         """Test Poduct Search on Amazon UK.
         
         Tests that a product search on Amazon UK is working and that the


### PR DESCRIPTION
I'm testing the UK store now and the name of the test case was still saying Germany.
