### PR TITLE
Improve the test for a valid root element.

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -274,7 +274,7 @@ class AmazonProduct(object):
             Element or None.
         """
         elements = path.split('.')
-        parent = root or self.item
+        parent = root if root is not None else self.item
         for element in elements[:-1]:
             parent = getattr(parent, element, None)
             if parent is None:


### PR DESCRIPTION
We can't continue to use the `a = b or c` idiom here because a valid
root element ("b") has implicit `__nonzero__()` behavior based on its
`__len__()` method.  It's better to test directly for the `None`
sentinel value here.

In addition, lxml has deprecated the `__len__()` method on Elements,
so this code was indirectly producing a runtime warning.
