### PR TITLE
Fix: Release date to return the right attribute

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -527,7 +527,7 @@ class AmazonProduct(object):
         :return:
             Release date (datetime.date)
         """
-        return self._safe_get_element_date('ItemAttributes.PublicationDate')
+        return self._safe_get_element_date('ItemAttributes.ReleaseDate')
 
     @property
     def edition(self):


### PR DESCRIPTION
The release date property was returning the publication date, unfortunately. Now it is returning the right thing.
