### PR TITLE
Pass kwargs to AmazonProduct

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -216,7 +216,8 @@ class AmazonSearch(object):
         """
         for page in self.iterate_pages():
             for item in getattr(page.Items, 'Item', []):
-                yield AmazonProduct(item, self.aws_associate_tag, self.api)
+                yield AmazonProduct(
+                    item, self.aws_associate_tag, self.api, **self.kwargs)
 
     def iterate_pages(self):
         """Iterate Pages.


### PR DESCRIPTION
Fixes bug where `region` isn't set for Amazon searches
