### PR TITLE
Fix unknown arg and MaxQS parameter in test from #38.

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -131,6 +131,7 @@ class AmazonAPI(object):
         # support older style calls
         if 'region' in kwargs:
             kwargs['Region'] = kwargs['region']
+            del kwargs['region']
         self.api = bottlenose.Amazon(
             aws_key, aws_secret, aws_associate_tag, **kwargs)
         self.aws_associate_tag = aws_associate_tag

--- a/tests.py
+++ b/tests.py
@@ -246,4 +246,4 @@ class TestAmazonApi(TestCase):
         assert_equals(amazon.region, 'UK')
 
     def test_kwargs(self):
-        amazon = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY, AMAZON_ASSOC_TAG, MaxQS=0.7)
+        amazon = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY, AMAZON_ASSOC_TAG, MaxQPS=0.7)


### PR DESCRIPTION
MaxQS should be MaxQPS.
When we redirect 'region' we need to delete the old kwarg.

Not sure why Travis said this passed the tests.
