### PR TITLE
added 'IN' domain to work with Amazon India

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -28,6 +28,7 @@ DOMAINS = {
     'DE': 'de',
     'ES': 'es',
     'FR': 'fr',
+    'IN': 'in',
     'IT': 'it',
     'JP': 'co.jp',
     'UK': 'co.uk',


### PR DESCRIPTION
Bottlenose supports Amazon India now, so I added `IN` key to `DOMAINS` to support Amazon India.
