### PR TITLE
bottlenose now supports Amazon India

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Lookup on amazon.de instead of amazon.com by setting the region:
      >>> import bottlenose.api
      >>> region_options = bottlenose.api.SERVICE_DOMAINS.keys()
      >>> region_options
-     ['US', 'FR', 'CN', 'UK', 'CA', 'DE', 'JP', 'IT', 'ES']
+     ['US', 'FR', 'CN', 'UK', 'IN', 'CA', 'DE', 'JP', 'IT', 'ES']
      >>> amazon_de = AmazonAPI(AMAZON_ACCESS_KEY, AMAZON_SECRET_KEY, AMAZON_ASSOC_TAG, Region="DE")
      >>> product = amazon_de.lookup(ItemId='B0051QVF7A')
      >>> product.title


### PR DESCRIPTION
updated the example to reflect the same. and this will also show and make clear that even python-amazon-simple-product-api will now support Amazon India.
