### PR TITLE
Handle search with no results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ MANIFEST
 build/
 dist/
 .idea
+test_settings.py

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -538,7 +538,8 @@ class AmazonSearch(object):
         """
         response = self.api.ItemSearch(ResponseGroup=ResponseGroup, **kwargs)
         root = objectify.fromstring(response)
-        if root.Items.Request.IsValid == 'False':
+        if (hasattr(root.Items.Request, 'Errors') and
+                not hasattr(root.Items, 'Item')):
             code = root.Items.Request.Errors.Error.Code
             msg = root.Items.Request.Errors.Error.Message
             if code == 'AWS.ParameterOutOfRange':

--- a/tests.py
+++ b/tests.py
@@ -3,7 +3,11 @@ from unittest import TestCase
 from nose.tools import assert_equals, assert_true, assert_false
 
 import datetime
-from amazon.api import AmazonAPI, CartException, CartInfoMismatchException
+from amazon.api import (AmazonAPI,
+                        CartException,
+                        CartInfoMismatchException,
+                        SearchException,
+                        AsinNotFound)
 from test_settings import (AMAZON_ACCESS_KEY,
                            AMAZON_SECRET_KEY,
                            AMAZON_ASSOC_TAG)
@@ -97,6 +101,13 @@ class TestAmazonApi(TestCase):
         assert_equals(product.browse_nodes[0].id, 2642129011)
         assert_equals(product.browse_nodes[0].name, 'eBook Readers')
 
+    def test_lookup_nonexistent_asin(self):
+        """Test Product Lookup with a nonexistent ASIN.
+
+        Tests that a product lookup for a nonexistent ASIN raises AsinNotFound.
+        """
+        self.assertRaises(AsinNotFound, self.amazon.lookup, ItemId="ABCD1234")
+
     def test_batch_lookup(self):
         """Test Batch Product Lookup.
 
@@ -135,6 +146,16 @@ class TestAmazonApi(TestCase):
             SearchIndex='All'
         )
         assert_equals(len(products), 1)
+
+    def test_search_no_results(self):
+        """Test Product Search with no results.
+
+        Tests that a product search with that returns no results throws a
+        SearchException.
+        """
+        products = self.amazon.search(Title='HarryPotter',
+                                      SearchIndex='Automotive')
+        self.assertRaises(SearchException, (x for x in products).next)
 
     def test_amazon_api_defaults_to_US(self):
         """Test Amazon API defaults to the US store."""


### PR DESCRIPTION
When searching a nonexistent product with valid parameters (e.g. `Title='HarryPotter', SearchIndex='Automotive'`) the Amazon API returns a response where `IsValid` is `True` but contains an `Errors` node. This causes the iterator of `AmazonSearch` API to fetch all the 10 item pages before returning an error. I modified the code that checks for `IsValid` to instead look for an `Errors` node in a response with no `Item`s. This way the error is returned on the first request.