### PR TITLE
change dateutil to dateutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before you get started, make sure you have:
 
 * Installed [Bottlenose](https://github.com/lionheart/bottlenose) (`pip install bottlenose`)
 * Installed lxml (`pip install lxml`)
-* Installed [dateutil](http://labix.org/python-dateutil) (`pip install dateutil`)
+* Installed [dateutil](http://labix.org/python-dateutil) (`pip install dateutils`)
 * An Amazon Product Advertising account
 * An AWS account
 


### PR DESCRIPTION
Hi,
I'm new on python language, when I try install dateutil, I can't install dateutil with this command
```
pip install dateutil
```

instead, I use this
```
pip install dateutils
```

so, I edit the readme, I hope it will useful for other