### PR TITLE
Add python-dateutil to install_requires in setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name='python-amazon-simple-product-api',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=True,
-      install_requires=["bottlenose", "lxml"],
+      install_requires=["bottlenose", "lxml", "python-dateutil"],
 )


### PR DESCRIPTION
By this change, `python-dateutil` will be automatically installed by `pip install python-amazon-simple-product-api`.