### PR TITLE
Fix installation instruction of dateutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before you get started, make sure you have:
 
 * Installed [Bottlenose](https://github.com/lionheart/bottlenose) (`pip install bottlenose`)
 * Installed lxml (`pip install lxml`)
-* Installed [dateutil](http://labix.org/python-dateutil) (`pip install dateutils`)
+* Installed [dateutil](http://labix.org/python-dateutil) (`pip install python-dateutil`)
 * An Amazon Product Advertising account
 * An AWS account
 


### PR DESCRIPTION
Package name should be `python-dateutil` not `dateutils`.
`dateutils` is a different package from `python-dateutil`.

https://pypi.python.org/pypi/python-dateutil
https://pypi.python.org/pypi/dateutils