### PR TITLE
Add exception handling for Amazon throttling a request.

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -80,6 +80,13 @@ class NoMorePages(SearchException):
     pass
 
 
+class RequestThrottled(AmazonException):
+    """Exception for when Amazon has throttled a request, per:
+    http://docs.aws.amazon.com/AWSECommerceService/latest/DG/ErrorNumbers.html
+    """
+    pass
+
+
 class SimilartyLookupException(AmazonException):
     """Similarty Lookup Exception.
     """
@@ -553,6 +560,9 @@ class AmazonSearch(object):
             msg = root.Items.Request.Errors.Error.Message
             if code == 'AWS.ParameterOutOfRange':
                 raise NoMorePages(msg)
+            elif code == 'HTTP Error 503':
+                raise RequestThrottled(
+                    "Request Throttled Error: '{0}', '{1}'".format(code, msg))
             else:
                 raise SearchException(
                     "Amazon Search Error: '{0}', '{1}'".format(code, msg))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 bottlenose
 python-dateutil
+nose


### PR DESCRIPTION
Hi,

I've been working with your API (which is great) and once in a while if people on my site use the api too frequently I'm getting a 503 error returned. This code adds handling for 503 errors that are explained as throttled requests here: http://docs.aws.amazon.com/AWSECommerceService/latest/DG/ErrorNumbers.html

I'm not sure how I could test this - probably could create a mock of the bottlenose response, but is that necessary?

Let me know if I can improve (and whether it's not even necessary). I'm new to open source and this is my first pull request ever (!), so any feedback would be fantastic!