### PR TITLE
Add Offer ID to API

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -685,6 +685,15 @@ class AmazonProduct(LXMLWrapper):
             return None, None
 
     @property
+    def offer_id(self):
+        """Offer ID
+        
+        :return:
+            Offer ID (string).
+        """
+        return self._safe_get_element('Offers.Offer.OfferListing.OfferListingId')
+
+    @property
     def asin(self):
         """ASIN (Amazon ID)
 


### PR DESCRIPTION
Offer ID is used to add items to a remote cart. Therefore it would be helpful to access it directly from the returned Amazon Product.