### PR TITLE
New method similar_productos() of AmazonProduct object

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -679,8 +679,8 @@ class AmazonProduct(LXMLWrapper):
         """
 
         result = []
-        similar_products = self._safe_get_element('SimilarProducts')
-        if similar_product is not None:
+        similar_products = self._safe_get_element('SimilarProducts.SimilarProduct')
+        if similar_products is not None:
             for similar_product in similar_products:
                 result.append(similar_product.ASIN.text)
         return result

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -671,6 +671,21 @@ class AmazonProduct(LXMLWrapper):
         self.region = kwargs.get('region', 'US')
 
     @property
+    def similar_products(self):
+        """SimlarProducts.
+        
+        :return:
+            List Of ASIN Similar Products (list)
+        """
+
+        result = []
+        similar_products = self._safe_get_element('SimilarProducts')
+        if similar_product is not None:
+            for similar_product in similar_products:
+                result.append(similar_product.ASIN.text)
+        return result
+
+    @property
     def price_and_currency(self):
         """Get Offer Price and Currency.
 


### PR DESCRIPTION
I added this method to AmazonProduct objects. Its an interesting method to discover other products:

```
    @property
    def similar_products(self):
        """SimlarProducts.

        :return:
            List Of ASIN Similar Products (list)
        """

        result = []
        similar_products = self._safe_get_element('SimilarProducts')
        if similar_product is not None:
            for similar_product in similar_products:
                result.append(similar_product.ASIN.text)
        return result
```
