### PR TITLE
Use `Decimal` for prices instead of `float`

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -19,6 +19,7 @@ from itertools import islice
 import bottlenose
 from lxml import objectify, etree
 import dateutil.parser
+from decimal import Decimal
 
 
 # https://kdp.amazon.com/help?topicId=A1CT8LK6UW2FXJ
@@ -688,7 +689,7 @@ class AmazonProduct(LXMLWrapper):
         :return:
             A tuple containing:
 
-                1. Float representation of price.
+                1. Decimal representation of price.
                 2. ISO Currency code (string).
         """
         price = self._safe_get_element_text(
@@ -708,8 +709,8 @@ class AmazonProduct(LXMLWrapper):
                 currency = self._safe_get_element_text(
                     'OfferSummary.LowestNewPrice.CurrencyCode')
         if price:
-            fprice = float(price) / 100 if 'JP' not in self.region else price
-            return fprice, currency
+            dprice = Decimal(price) / 100 if 'JP' not in self.region else Decimal(price)
+            return dprice, currency
         else:
             return None, None
 
@@ -1117,14 +1118,15 @@ class AmazonProduct(LXMLWrapper):
         :return:
             A tuple containing:
 
-                1. Float representation of price.
+                1. Decimal representation of price.
                 2. ISO Currency code (string).
         """
         price = self._safe_get_element_text('ItemAttributes.ListPrice.Amount')
         currency = self._safe_get_element_text(
             'ItemAttributes.ListPrice.CurrencyCode')
         if price:
-            return float(price) / 100, currency
+            dprice = Decimal(price) / 100 if 'JP' not in self.region else Decimal(price)
+            return dprice, currency
         else:
             return None, None
 

--- a/tests.py
+++ b/tests.py
@@ -8,6 +8,7 @@ from flaky import flaky
 
 import time
 import datetime
+from decimal import Decimal
 from amazon.api import (AmazonAPI,
                         CartException,
                         CartInfoMismatchException,
@@ -406,6 +407,20 @@ class TestAmazonApi(unittest.TestCase):
     def test_formatted_price(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
         assert_equals(product.formatted_price, '$12.49')
+
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
+    def test_price_and_currency(self):
+        product = self.amazon.lookup(ItemId="B01NBTSVDN")
+        price, currency = product.price_and_currency
+        assert_equals(price, Decimal('12.49'))
+        assert_equals(currency, 'USD')
+
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
+    def test_list_price(self):
+        product = self.amazon.lookup(ItemId="B01NBTSVDN")
+        price, currency = product.list_price
+        assert_equals(price, Decimal('12.49'))
+        assert_equals(currency, 'USD')
 
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_running_time(self):


### PR DESCRIPTION
As suggested in #102 I changed the prices to use `Decimal` instead of `float`. I think it's a good improvement due to floating point precision issues as mentioned by @andryr

Additionally, I added two test cases for the properties `list_price` and `price_and_currency`.

[![Build Status](https://travis-ci.org/norman-thomas/python-amazon-simple-product-api.svg?branch=decimal-prices)](https://travis-ci.org/norman-thomas/python-amazon-simple-product-api)