### PR TITLE
Add a MANIFEST.in to ensure README.md (and all other files) are included in packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include *.md *.rst *.txt INSTALL LICENSE tox.ini .travis.yml docs/Makefile
+include tests.py
+recursive-include docs *.py
+recursive-include docs *.rst
+prune docs/_build


### PR DESCRIPTION
Based on <https://github.com/python-attrs/attrs/blob/master/MANIFEST.in> and verified with with <https://github.com/mgedmin/check-manifest>.

Without this, you can't actually install from PyPI because `setup.py` fails to find `README.md`.