### PR TITLE
Defaults number of node children to empty list, for nodes which do no…

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -654,7 +654,7 @@ class AmazonBrowseNode(LXMLWrapper):
     A list of this browse node's children in the browse node tree.
     """
         children = []
-        child_nodes = getattr(self.parsed_response, 'Children')
+        child_nodes = getattr(self.parsed_response, 'Children', [])
         for child in getattr(child_nodes, 'BrowseNode', []):
             children.append(AmazonBrowseNode(child))
         return children

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -743,22 +743,13 @@ class AmazonProduct(LXMLWrapper):
         return self._safe_get_element_text('ASIN')
 
     @property
-    def total_offers(self):
-        """Total offers
-
-        :return:
-            Total offers (integer).
-        """
-        return self._safe_get_element_text('Offers.TotalOffers')
-
-    @property
     def total_new(self):
         """Total offers
 
         :return:
             Total offers (integer).
         """
-        return self._safe_get_element_text('Offers.TotalNew')
+        return self._safe_get_element_text('OfferSummary.TotalNew')
 
     @property
     def total_used(self):
@@ -767,7 +758,7 @@ class AmazonProduct(LXMLWrapper):
         :return:
             Total used (integer).
         """
-        return self._safe_get_element_text('Offers.TotalUsed')
+        return self._safe_get_element_text('OfferSummary.TotalUsed')
 
     @property
     def total_refurbished(self):
@@ -776,7 +767,7 @@ class AmazonProduct(LXMLWrapper):
         :return:
             Total refurbished (integer).
         """
-        return self._safe_get_element_text('Offers.TotalRefurbished')
+        return self._safe_get_element_text('OfferSummary.TotalRefurbished')
 
     @property
     def total_collectible(self):
@@ -785,7 +776,7 @@ class AmazonProduct(LXMLWrapper):
         :return:
             Total collectible (integer).
         """
-        return self._safe_get_element_text('Offers.TotalCollectible')
+        return self._safe_get_element_text('OfferSummary.TotalCollectible')
 
     @property
     def item_height(self):

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -743,6 +743,123 @@ class AmazonProduct(LXMLWrapper):
         return self._safe_get_element_text('ASIN')
 
     @property
+    def total_offers(self):
+        """Total offers
+
+        :return:
+            Total offers (integer).
+        """
+        return self._safe_get_element_text('Offers.TotalOffers')
+
+    @property
+    def total_new(self):
+        """Total offers
+
+        :return:
+            Total offers (integer).
+        """
+        return self._safe_get_element_text('Offers.TotalNew')
+
+    @property
+    def total_used(self):
+        """Total used
+
+        :return:
+            Total used (integer).
+        """
+        return self._safe_get_element_text('Offers.TotalUsed')
+
+    @property
+    def total_refurbished(self):
+        """Total refurbished
+
+        :return:
+            Total refurbished (integer).
+        """
+        return self._safe_get_element_text('Offers.TotalRefurbished')
+
+    @property
+    def total_collectible(self):
+        """Total collectible
+
+        :return:
+            Total collectible (integer).
+        """
+        return self._safe_get_element_text('Offers.TotalCollectible')
+
+    @property
+    def item_height(self):
+        """Item height
+
+        :return:
+            Item height (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.ItemDimensions.Height')
+
+    @property
+    def item_width(self):
+        """Item width
+
+        :return:
+            Item width (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.ItemDimensions.Width')
+
+    @property
+    def item_length(self):
+        """Item length
+
+        :return:
+            Item length (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.ItemDimensions.Length')
+
+    @property
+    def item_weight(self):
+        """Item weight
+
+        :return:
+            Item weight (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.ItemDimensions.Weight')
+
+    @property
+    def package_height(self):
+        """Package height
+
+        :return:
+            Package height (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.PackageDimensions.Height')
+
+    @property
+    def package_width(self):
+        """Package width
+
+        :return:
+            Package width (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.PackageDimensions.Width')
+
+    @property
+    def package_length(self):
+        """Package length
+
+        :return:
+            Package length (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.PackageDimensions.Length')
+
+    @property
+    def package_weight(self):
+        """Package weight
+
+        :return:
+            Package weight (integer).
+        """
+        return self._safe_get_element_text('ItemAttributes.PackageDimensions.Weight')
+
+    @property
     def sales_rank(self):
         """Sales Rank
 


### PR DESCRIPTION
Defaults number of node children to empty list, for nodes which do not have sub-nodes. This will prevent errors such as from occuring: 'AttributeError: no such child: {http://webservices.amazon.com/AWSECommerceService/2013-08-01}Children'.