### PR TITLE
Added support for AternateVersions Response group

### DIFF
--- a/amazon/api.py
+++ b/amazon/api.py
@@ -256,7 +256,7 @@ class AmazonAPI(object):
         response = self.api.BrowseNodeLookup(
             ResponseGroup=ResponseGroup, **kwargs)
         root = objectify.fromstring(response)
-        if root.BrowseNodes.Request.IsValid == 'False':
+        if hasattr(root.BrowseNodes.Request, 'Errors'):
             code = root.BrowseNodes.Request.Errors.Error.Code
             msg = root.BrowseNodes.Request.Errors.Error.Message
             raise BrowseNodeLookupException(

--- a/amazon/api.py
+++ b/amazon/api.py
@@ -1140,6 +1140,34 @@ class AmazonProduct(LXMLWrapper):
         else:
             return None, None
 
+    @property
+    def alternate_versions(self):
+        """AlternateVersions.
+
+        Returns a list of dicts of items. Used for a search or lookup
+        using the `ResponseGroup="AlternateVersions"` keyword argument.
+
+        :return:
+            Returns a list of dicts with the keys 'asin', 'title', and
+            'binding.
+        """
+
+        def version_dict(version):
+            asin = self._safe_get_element_text('ASIN', root=version)
+            title = self._safe_get_element_text('Title', root=version)
+            binding = self._safe_get_element_text('Binding', root=version)
+            return {'asin': asin,
+                    'title': title,
+                    'binding': binding}
+
+        alternates_elm = self._safe_get_element('AlternateVersions')
+        if alternates_elm is not None:
+            versions = [version_dict(version)
+                        for version in alternates_elm.getchildren()]
+            return versions
+        else:
+            return []
+
     def get_attribute(self, name):
         """Get Attribute
 

--- a/tests.py
+++ b/tests.py
@@ -14,7 +14,8 @@ from amazon.api import (AmazonAPI,
                         CartInfoMismatchException,
                         SearchException,
                         AmazonSearch,
-                        AsinNotFound)
+                        AsinNotFound,
+                        BrowseNodeLookupException)
 
 _AMAZON_ACCESS_KEY = None
 _AMAZON_SECRET_KEY = None
@@ -214,7 +215,6 @@ class TestAmazonApi(unittest.TestCase):
             pass
         assert_true(products.is_last_page)
 
-
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_search_no_results(self):
         """Test Product Search with no results.
@@ -288,6 +288,10 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(bn.id, bnid)
         assert_equals(bn.name, 'eBook Readers')
         assert_equals(bn.is_category_root, False)
+        invalid_bnid = 1036682
+        assert_raises(BrowseNodeLookupException,
+                      self.amazon.browse_node_lookup,
+                      BrowseNodeId=invalid_bnid)
 
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_obscure_date(self):
@@ -432,7 +436,7 @@ class TestAmazonApi(unittest.TestCase):
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_is_preorder(self):
         product = self.amazon.lookup(ItemId="B01NBTSVDN")
-        assert_equals(product.is_preorder , None)
+        assert_equals(product.is_preorder, None)
 
     @flaky(max_runs=3, rerun_filter=delay_rerun)
     def test_detail_page_url(self):
@@ -463,7 +467,6 @@ class TestAmazonApi(unittest.TestCase):
         product = self.amazon.lookup(ItemId="B00ZV9PXP2")
         assert_equals(product.availability_min_hours, '0')
         assert_equals(product.availability_max_hours, '0')
-
 
     def test_kwargs(self):
         amazon = AmazonAPI(_AMAZON_ACCESS_KEY, _AMAZON_SECRET_KEY,

--- a/tests.py
+++ b/tests.py
@@ -481,6 +481,29 @@ class TestAmazonApi(unittest.TestCase):
         assert_equals(type(product.images), list)
         assert_equals(len(product.images), 7)
 
+    @flaky(max_runs=3, rerun_filter=delay_rerun)
+    def test_alternate_versions(self):
+        """Test alternate_versions property
+
+        Test that the images property has a value when using the
+        AlternateVersions ResponseGroup.
+
+        This test tries to be as perminant as possible. It doesn't
+        depend on any specific results that could be ruined if a new
+        version is added that ends up being the first one in the list,
+        instead only checking that an alternate version is returned
+        and that it has the right properties.
+        """
+        product = self.amazon.lookup(ResponseGroup='AlternateVersions',
+                                     ItemId='1491914254')
+        assert_equals(type(product.alternate_versions), list)
+        assert_true(len(product.alternate_versions) > 0)
+        assert_equals(type(product.alternate_versions[0]), dict)
+        assert_equals(len(product.alternate_versions[0]), 3)
+        assert_true('asin' in product.alternate_versions[0].keys())
+        assert_true('title' in product.alternate_versions[0].keys())
+        assert_true('binding' in product.alternate_versions[0].keys())
+
 
 class TestAmazonCart(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Adds support for another response group. Part of the long slog to add support for #60.

I modeled this on how we support the "Images" response group. I'm not sure if it's the right way to do it, but I figured I should be consistent with the current API.

Here's some example usage:
```
In [11]: lookup_result = amazon.lookup(ItemId="1491914254", ResponseGroup='AlternateVersions')

In [12]: lookup_result.alternate_versions
Out[12]: 
[{'asin': '9352136047',
  'binding': 'Paperback',
  'title': "Deep Learning: A Practitioner's Approach"},
 {'asin': 'B074D5YF1D',
  'binding': 'Kindle Edition',
  'title': "Deep Learning: A Practitioner's Approach"}]
```